### PR TITLE
Add simple searching of all question fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ npm-debug.log
 
 /.env.dev
 /kubernetes/*-config.yml
+
+# Ignore the output of mix ecto.dump
+/priv/repo/structure.sql

--- a/lib/smart_note/notes.ex
+++ b/lib/smart_note/notes.ex
@@ -11,6 +11,13 @@ defmodule SmartNote.Notes do
   alias SmartNote.Repo
 
   @doc """
+  Preload creating user onto the note data object for easy querying
+  """
+  def preload(note) do
+    Repo.preload(note, [:user])
+  end
+
+  @doc """
   Changeset for a new note
   """
   def new(user) do

--- a/lib/smart_note/questions/question.ex
+++ b/lib/smart_note/questions/question.ex
@@ -24,11 +24,21 @@ defmodule SmartNote.Questions.Question do
     struct
     |> cast(params, [:title, :body, :answer, :libraries, :tags])
     |> validate_required([:title, :body, :answer, :tags])
+    |> validate_libraries_format
   end
 
   def update_changeset(struct, params) do
     struct
     |> cast(params, [:title, :body, :answer, :libraries, :tags])
     |> validate_required([:title, :body, :answer, :tags])
+    |> validate_libraries_format
+  end
+
+  defp validate_libraries_format(struct) do
+    struct
+    |> validate_format(
+      :libraries,
+      ~r/(?:(?:hex|npm)\s+[A-Za-z0-9_-]+\s+[~=><]+\s+[0-9\.]+\n?){1,}/u
+    )
   end
 end

--- a/lib/smart_note/questions/question.ex
+++ b/lib/smart_note/questions/question.ex
@@ -34,6 +34,14 @@ defmodule SmartNote.Questions.Question do
     |> validate_libraries_format
   end
 
+  # Why is this so cursed?
+  # `libraries` is a big text field that should look for example like:
+  #     hex ecto ~> 3.0
+  #     hex foobar == 1.0
+  #     npm dataclice > 0.1
+  #
+  # So, let's just make sure we always have that format for every line
+  # here so we don't have to mess around further upstream with bad data.
   defp validate_libraries_format(struct) do
     struct
     |> validate_format(

--- a/lib/smart_note/users.ex
+++ b/lib/smart_note/users.ex
@@ -8,6 +8,13 @@ defmodule SmartNote.Users do
   alias SmartNote.Users.User
 
   @doc """
+  Preload notes onto the user data object for easy querying
+  """
+  def preload(user) do
+    Repo.preload(user, [:notes])
+  end
+
+  @doc """
   Changeset for updating a user
   """
   def edit(user), do: Ecto.Changeset.change(user, %{})

--- a/lib/web/controllers/page_controller.ex
+++ b/lib/web/controllers/page_controller.ex
@@ -21,6 +21,29 @@ defmodule Web.PageController do
     end
   end
 
+  def search(conn, %{"search-term" => search_term} = _params) do
+    search_term = String.strip(search_term)
+
+    case String.length(search_term) > 0 do
+      true ->
+        %{page: page, per: per} = conn.assigns
+
+        %{page: questions, pagination: pagination} =
+          Questions.all(page: page, per: per, search_term: search_term)
+
+        conn
+        |> assign(:search_term, search_term)
+        |> assign(:pagination, pagination)
+        |> assign(:questions, questions)
+        |> render("questions.html")
+
+      false ->
+        conn
+        |> put_flash(:error, "Invalid search string")
+        |> redirect(to: Routes.page_path(conn, :index))
+    end
+  end
+
   def health(conn, _params) do
     send_resp(conn, 200, "OK\n")
   end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -35,6 +35,8 @@ defmodule Web.Router do
   scope "/", Web do
     pipe_through([:browser, :logged_in])
 
+    get("/search", PageController, :search)
+
     resources("/notes", NoteController, except: [:delete])
 
     resources("/questions", QuestionController, except: [:index, :show])

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -36,6 +36,11 @@
           <ul class="list-reset flex justify-between flex-1 md:flex-none items-center">
             <%= if Map.has_key?(assigns, :current_user) do %>
               <li class="mr-3">
+                <%= form_tag "/search", method: "get" do %>
+                  <%= tag(:input, type: "text", name: "search-term", placeholder: "search terms", value: Web.LayoutView.search_term(@conn)) %>
+                <% end %>
+              </li>
+              <li class="mr-3">
                 <%= link(to: Routes.question_path(@conn, :new), class: "inline-block text-white no-underline hover:text-gray-200 hover:text-underline py-2 px-4") do %>
                   <i class="fa fa-plus"></i> Question
                 <% end %>

--- a/lib/web/templates/page/questions.html.eex
+++ b/lib/web/templates/page/questions.html.eex
@@ -1,5 +1,5 @@
 <div class="bg-white shadow-md rounded p-8 mx-4 sm:mx-0">
-  <p class="text-4xl">Questions</p>
+  <h2 class="text-4xl"><%= Web.LayoutView.question_header_text(@conn) %></h2>
 
   <%= render(QuestionView, "_questions.html", questions: @questions, conn: @conn) %>
 

--- a/lib/web/templates/question/_questions.html.eex
+++ b/lib/web/templates/question/_questions.html.eex
@@ -9,4 +9,7 @@
       </div>
     </li>
   <% end) %>
+  <%=  if Enum.empty?(@questions) do %>
+    <li class="border my-2">No Questions Found</li>
+  <% end %>
 </ul>

--- a/lib/web/views/layout_view.ex
+++ b/lib/web/views/layout_view.ex
@@ -2,4 +2,18 @@ defmodule Web.LayoutView do
   use Web, :view
 
   import Web.Gettext, only: [gettext: 1]
+
+  def search_term(conn) do
+    conn.assigns[:search_term]
+  end
+
+  def question_header_text(conn) do
+    search_term = Web.LayoutView.search_term(conn)
+
+    if is_nil(search_term) do
+      "Questions"
+    else
+      "Questions matching '#{search_term}'"
+    end
+  end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,8 +1,1 @@
-{:ok, _user} =
-  SmartNote.Users.create(%{
-    email: "user@example.com",
-    first_name: "John",
-    last_name: "Smith",
-    password: "password",
-    password_confirmation: "password"
-  })
+# TODO: make a user stub that doesn't rely on github


### PR DESCRIPTION
Why is this change needed?
--------------------------
As the number of questions answered increase, it becomes more and more
difficult to find one that is relevant to you, or even one you know
exists.

How does it address the issue?
------------------------------
This is a naive implementation of full text search for questions. There
may be a way to do it but I couldn't figure out how to do substring
matching on tags so if you want to search by tag you must provide the
full tag name.

This also doesn't do any ranking or highlighting of matches. I suspect a
different approach that would work well would be adding all the question
metadata into the page and doing JS searches, though that breaks down
once you start paginating.

Also this is "naive" because it doesn't actually use any of postgres's
full text features.

Any links to any relevant tickets, articles or other resources?
--------------------------------------------------------------
Some helpful links for this version were:
* [Fast Full-text Search with Ecto and
PostgreSQL](https://nathanmlong.com/2018/01/fast-fulltext-search-with-ecto-and-postgresql/)
* [Postgres full-text search is Good
Enough!](http://rachbelaid.com/postgres-full-text-search-is-good-enough/)

I used neither of them for the solution, but many further improvements
could be gotten by following along what they did.

Issues Addressed
---------------
* Fixes #4
* Fixes #5
* Fixes #6
* Fixes #7
* seeding was broken - this just deletes the broken seed so it runs as a no-op
* add some preload functions for notes and users
* validate question's `libraries` field so the app doesn't get into a broken state if you don't enter it exactly right